### PR TITLE
chore(ci): add pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -33,4 +33,3 @@ jobs:
             - Executed hooks to surface potential breakages
           branch: chore/pre-commit-autoupdate-bot
           delete-branch: true
-

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,36 @@
+---
+name: pre-commit autoupdate
+
+on:
+  schedule:
+    - cron: "0 0 1 * *" # monthly, 00:00 UTC on the 1st
+  workflow_dispatch:
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Run hooks to surface breaking changes
+        run: pre-commit run --all-files || true
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(pre-commit): autoupdate hooks"
+          title: "chore: pre-commit autoupdate"
+          body: |
+            Automated pre-commit hook updates.
+            - Ran `pre-commit autoupdate`
+            - Executed hooks to surface potential breakages
+          branch: chore/pre-commit-autoupdate-bot
+          delete-branch: true
+


### PR DESCRIPTION
Adds a scheduled monthly workflow to run pre-commit autoupdate and open a PR with updated hook versions.