### PR TITLE
feat: API resilience (errors, retry/backoff) and datetime parsing

### DIFF
--- a/pysmartcocoon/fan.py
+++ b/pysmartcocoon/fan.py
@@ -320,7 +320,21 @@ class Fan:
         self._firmware_version = data["firmware_version"]
         self._is_room_estimating = data["is_room_estimating"]
         self._connected = data["connected"]
-        self._last_connection = data["last_connection"]
+        # Parse last_connection to datetime when provided as string
+        last_conn = data["last_connection"]
+        if isinstance(last_conn, str):
+            try:
+                iso_str = last_conn.replace("Z", "+00:00")
+                self._last_connection = datetime.fromisoformat(iso_str)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "Fan ID: %s - Unable to parse last_connection: %s",
+                    self.fan_id,
+                    last_conn,
+                )
+                self._last_connection = None
+        else:
+            self._last_connection = last_conn
         self._power = data["power"]
         self._predicted_room_temperature = data["predicted_room_temperature"]
         self._room_id = data["room_id"]

--- a/pysmartcocoon/manager.py
+++ b/pysmartcocoon/manager.py
@@ -8,6 +8,7 @@ from aiohttp import ClientSession
 
 from pysmartcocoon.api import SmartCocoonAPI
 from pysmartcocoon.const import API_URL, DEFAULT_TIMEOUT, EntityType, FanMode
+from pysmartcocoon.errors import RequestError, UnauthorizedError
 from pysmartcocoon.fan import Fan
 from pysmartcocoon.location import Location
 from pysmartcocoon.room import Room
@@ -84,7 +85,13 @@ class SmartCocoonManager:
     async def async_update_locations(self) -> dict[int, Location]:
         """Update location data"""
         entity = EntityType.LOCATIONS.value
-        response = await self._api.async_request("GET", f"{API_URL}{entity}")
+        try:
+            response = await self._api.async_request(
+                "GET", f"{API_URL}{entity}"
+            )
+        except (UnauthorizedError, RequestError) as err:
+            _LOGGER.debug("Failed to update locations: %s", err)
+            return self._locations
 
         if response and entity in response:
             for item in response[entity]:
@@ -96,7 +103,13 @@ class SmartCocoonManager:
     async def async_update_thermostats(self) -> dict[int, Thermostat]:
         """Update thermostate data"""
         entity = EntityType.THERMOSTATS.value
-        response = await self._api.async_request("GET", f"{API_URL}{entity}")
+        try:
+            response = await self._api.async_request(
+                "GET", f"{API_URL}{entity}"
+            )
+        except (UnauthorizedError, RequestError) as err:
+            _LOGGER.debug("Failed to update thermostats: %s", err)
+            return self._thermostats
 
         if response and entity in response:
             for item in response[entity]:
@@ -108,7 +121,13 @@ class SmartCocoonManager:
     async def async_update_rooms(self) -> dict[int, Room]:
         """Update rooms data"""
         entity = EntityType.ROOMS.value
-        response = await self._api.async_request("GET", f"{API_URL}{entity}")
+        try:
+            response = await self._api.async_request(
+                "GET", f"{API_URL}{entity}"
+            )
+        except (UnauthorizedError, RequestError) as err:
+            _LOGGER.debug("Failed to update rooms: %s", err)
+            return self._rooms
 
         if response and entity in response:
             for item in response[entity]:
@@ -120,7 +139,13 @@ class SmartCocoonManager:
     async def async_update_fans(self) -> dict[str, Fan]:
         """Update fans data"""
         entity = EntityType.FANS.value
-        response = await self._api.async_request("GET", f"{API_URL}{entity}")
+        try:
+            response = await self._api.async_request(
+                "GET", f"{API_URL}{entity}"
+            )
+        except (UnauthorizedError, RequestError) as err:
+            _LOGGER.debug("Failed to update fans: %s", err)
+            return self._fans
 
         if response and entity in response:
             for data in response[entity]:


### PR DESCRIPTION
- Raise UnauthorizedError/RequestError from async_request instead of returning None\n- Add simple exponential backoff for transient errors; surface 401/403 for reauth\n- Parse last_connection to datetime; handle missing/invalid values\n- Manager catches domain errors and degrades gracefully\n\nAll hooks pass; this improves robustness for HA integration.