### PR TITLE
feat(ci): publish to PyPI automatically via Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  DEFAULT_PYTHON: 3.13.2
+
+# No secrets are used anywhere in this workflow. Publishing authenticates to
+# PyPI with a short-lived OIDC token minted by GitHub at run time (Trusted
+# Publishing), so there is no long-lived API token to store or rotate.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build distribution
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+
+      # Guard against publishing a tag whose version does not match the
+      # package metadata. bumpver keeps these in step, but a hand-made tag
+      # can drift, and a wrong version on PyPI cannot be reused.
+      - name: Verify tag matches project version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          project_version="$(
+            python -c 'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])'
+          )"
+          echo "tag=${tag_version} pyproject=${project_version}"
+          if [ "${tag_version}" != "${project_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${project_version}"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish to PyPI
+    needs: build
+    # The environment gates who/what can publish and is the second half of the
+    # Trusted Publishing match on pypi.org. Add required reviewers to this
+    # environment in repo settings if you ever want a manual approval step.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pysmartcocoon
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — push a `vX.Y.Z` tag, and the package builds and publishes to PyPI on its own. Releases are currently fully manual (`python -m build` + `twine upload` with an API token).

## Why Trusted Publishing

PyPI mints a short-lived OIDC token for the workflow run itself. There is **no API token in repository secrets**, nothing to rotate, and nothing to leak. The publish job is the only one with elevated permission (`id-token: write`); everything else is `contents: read`.

## Safety

- **Tag/version guard** — the build fails if the pushed tag disagrees with `pyproject.toml`. A wrong version on PyPI can never be reused, so this is worth failing loudly over.
- **`twine check`** runs on the built artifacts before anything is uploaded.
- **Build and publish are separate jobs** — the package is fully built and validated before the job holding `id-token: write` starts.
- **`pypi` environment** — add required reviewers to it in repo settings if you ever want a manual approval gate before upload.

## One-time setup needed before this works

On <https://pypi.org/manage/project/pysmartcocoon/settings/publishing/>, add a trusted publisher:

| Field | Value |
|---|---|
| Owner | `davecpearce` |
| Repository name | `pysmartcocoon` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

Until that entry exists, a tag push builds successfully and then fails at the upload step — it cannot publish anything wrong in the meantime.

## Releasing after this merges

```
bumpver update --patch    # bumps, commits, tags, pushes -> workflow publishes
```

## Note

This workflow was authored while `main`'s CI was verified working. Unrelated: `tests.yaml` in this repo has a `schedule:` trigger, which makes it eligible for GitHub's 60-day inactivity auto-disable — the same thing that had silently disabled CI in `hacs_smartcocoon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)