### PR TITLE
security(ci): pin actions to SHAs and add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 ---
 version: 2
+
+# Each ecosystem below sets a `cooldown`, which delays adoption of freshly
+# published versions. A compromised release is usually caught and yanked
+# within days, so waiting is the cheapest protection available -- and it
+# matters more here because patch and minor updates are auto-merged without a
+# human looking at them.
+
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -8,6 +15,11 @@ updates:
     # Raise pull requests for version updates
     # to github-actions against the `main` branch
     target-branch: "main"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:
@@ -15,6 +27,11 @@ updates:
     # Raise pull requests for version updates
     # to pip against the `main` branch
     target-branch: "main"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: pip
     directory: "/"
     schedule:
@@ -22,3 +39,8 @@ updates:
     # Raise pull requests for version updates
     # to pip against the `main` branch
     target-branch: "main"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5.3.0
         with:
           skip-delete: true

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -10,8 +10,8 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - name: Install pre-commit
@@ -23,7 +23,7 @@ jobs:
       - name: Run hooks to surface breaking changes
         run: pre-commit run --all-files || true
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: "chore(pre-commit): autoupdate hooks"
           title: "chore: pre-commit autoupdate"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     name: Build distribution
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
 
@@ -54,7 +54,7 @@ jobs:
           twine check dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -74,10 +74,10 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,9 @@ jobs:
     name: Pre-commit
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install dependencies


### PR DESCRIPTION
Mirrors the hardening applied to `hacs_smartcocoon` in davecpearce/hacs_smartcocoon#388.

## Pin every action to a commit SHA

A mutable tag like `@v6` can be repointed at any time by whoever controls the action — including an attacker who takes over that account. The version stays in a trailing comment, which dependabot reads and keeps updating, so this costs nothing in maintenance.

**The one that matters most is `pypa/gh-action-pypi-publish`**, which was tracking the `release/v1` **branch**. That action receives the OIDC token used to publish to PyPI, making it the single most valuable step in these workflows to compromise — and a branch ref moves by design. It is now pinned to `dc37677`.

## Dependabot cooldown

30d major / 7d minor / 3d patch, delaying adoption of freshly published versions. Relevant now that patch and minor updates are auto-merged without a human reading them: without a cooldown a compromised release could land within hours, and bad releases are typically yanked within days.

## Note on `tests.yaml`

This workflow has a `schedule:` trigger, which makes it eligible for GitHub's 60-day `disabled_inactivity` auto-disable — the same mechanism that had silently switched off CI in `hacs_smartcocoon` since 2026-05-27 without any notification. Worth watching for here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)