### PR TITLE
security: redact credentials from debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-08-06
+
+### Security
+
+- **Credentials no longer written to debug logs** - The debug logging added for troubleshooting dumped whole API requests and responses verbatim, which meant enabling `pysmartcocoon: debug` (as the README instructs) wrote the account password, bearer token, API client id, account email and per-fan `mqtt_password` into `home-assistant.log` in plaintext. Those logs are routinely pasted into public GitHub issues. All credentials are now replaced with `**REDACTED**` before logging, and email addresses are masked to `d***@example.com` so accounts can still be told apart.
+
+  **If you enabled debug logging for this integration, treat your SmartCocoon password as exposed** - rotate it, and check any logs you have shared publicly.
+
 ## [1.4.2] - 2025-12-29
 
 ### Fixed

--- a/pysmartcocoon/api.py
+++ b/pysmartcocoon/api.py
@@ -18,6 +18,7 @@ from pysmartcocoon.const import (
     DEFAULT_TIMEOUT,
 )
 from pysmartcocoon.errors import RequestError, UnauthorizedError
+from pysmartcocoon.redact import mask_identifier, redact
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -114,15 +115,18 @@ class SmartCocoonAPI:
             _LOGGER.debug("│ Method: %s", method)
             _LOGGER.debug("│ URL: %s", url)
             _LOGGER.debug(
-                "│ Headers:\n%s", json.dumps(self._headers_auth, indent=2)
+                "│ Headers:\n%s",
+                json.dumps(redact(self._headers_auth), indent=2),
             )
             if "json" in kwargs:
                 _LOGGER.debug(
                     "│ Request body (JSON):\n%s",
-                    json.dumps(kwargs["json"], indent=2),
+                    json.dumps(redact(kwargs["json"]), indent=2),
                 )
             if "data" in kwargs:
-                _LOGGER.debug("│ Request body (data): %s", kwargs["data"])
+                _LOGGER.debug(
+                    "│ Request body (data): %s", redact(kwargs["data"])
+                )
             _LOGGER.debug(
                 "└────────────────────────────────────────────────────────────"
             )
@@ -160,7 +164,9 @@ class SmartCocoonAPI:
                         _LOGGER.debug("│ Status: %s", response.status)
                         _LOGGER.debug(
                             "│ Headers:\n%s",
-                            json.dumps(dict(response.headers), indent=2),
+                            json.dumps(
+                                redact(dict(response.headers)), indent=2
+                            ),
                         )
 
                     response.raise_for_status()
@@ -169,7 +175,8 @@ class SmartCocoonAPI:
                     # Debug: Log response body
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug(
-                            "│ Response body:\n%s", json.dumps(data, indent=2)
+                            "│ Response body:\n%s",
+                            json.dumps(redact(data), indent=2),
                         )
                         _LOGGER.debug(
                             "└────────────────────────────────────────────────────────────"  # pylint: disable=line-too-long
@@ -228,7 +235,7 @@ class SmartCocoonAPI:
                 _LOGGER.debug(
                     "│ Email: %s",
                     (
-                        data["data"]["email"]
+                        mask_identifier(data["data"]["email"])
                         if data and "data" in data
                         else "Unknown"
                     ),

--- a/pysmartcocoon/redact.py
+++ b/pysmartcocoon/redact.py
@@ -1,0 +1,86 @@
+"""Redaction helpers for debug logging.
+
+This library logs whole API requests and responses at DEBUG level, and the
+README tells Home Assistant users to turn that logging on when something is
+wrong. Those logs routinely get pasted into public GitHub issues, so nothing
+written at DEBUG may contain a usable credential.
+
+Everything here is about what reaches a log file. None of it changes what is
+sent to the API.
+"""
+
+from typing import Any
+
+REDACTED = "**REDACTED**"
+
+# Matched case-insensitively as a substring of the key, so "access-token",
+# "mqtt_password" and "refresh_token" are all covered without having to
+# enumerate every spelling the API might introduce later.
+_SECRET_KEY_PARTS: tuple[str, ...] = (
+    "password",
+    "token",
+    "secret",
+    "authorization",
+    "api_key",
+    "apikey",
+)
+
+# Keys whose exact name identifies a credential, but which contain no
+# substring worth matching on. `client` is one third of this API's auth
+# triple (access-token + client + uid), so it is a credential, not metadata.
+_SECRET_KEY_EXACT: frozenset[str] = frozenset({"client"})
+
+# Account identifiers rather than credentials. Partially masked instead of
+# removed, so debug output can still tell two accounts apart -- which is the
+# reason someone would want the value in the first place.
+_IDENTIFIER_KEY_EXACT: frozenset[str] = frozenset({"email", "uid"})
+
+
+def _is_secret(key: str) -> bool:
+    lowered = key.lower()
+    if lowered in _SECRET_KEY_EXACT:
+        return True
+    return any(part in lowered for part in _SECRET_KEY_PARTS)
+
+
+def mask_identifier(value: Any) -> Any:
+    """Mask an account identifier, keeping just enough to tell accounts apart.
+
+    Email addresses keep their first character and domain, since the domain
+    is often the useful part when diagnosing a login problem and is not
+    secret. Anything else keeps only its first character.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+
+    if "@" in value:
+        local, _, domain = value.partition("@")
+        head = local[0] if local else ""
+        return f"{head}***@{domain}"
+
+    return f"{value[0]}***"
+
+
+def redact(obj: Any) -> Any:
+    """Return a copy of ``obj`` with credentials replaced.
+
+    Recurses through dicts and lists. The input is never mutated, so callers
+    can pass request bodies and API responses directly without risk of
+    corrupting the data actually in flight.
+    """
+    if isinstance(obj, dict):
+        result: dict[Any, Any] = {}
+        for key, value in obj.items():
+            if isinstance(key, str) and _is_secret(key):
+                result[key] = REDACTED
+            elif isinstance(key, str) and key.lower() in _IDENTIFIER_KEY_EXACT:
+                result[key] = mask_identifier(value)
+            else:
+                result[key] = redact(value)
+        return result
+
+    if isinstance(obj, (list, tuple)):
+        redacted = [redact(item) for item in obj]
+        return type(obj)(redacted) if isinstance(obj, tuple) else redacted
+
+    return obj

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -12,6 +12,7 @@ import logging
 
 import pytest
 
+from pysmartcocoon.api import SmartCocoonAPI
 from pysmartcocoon.const import API_AUTH_URL, API_HEADERS
 from pysmartcocoon.redact import REDACTED, mask_identifier, redact
 
@@ -80,9 +81,7 @@ def test_nested_and_listed_secrets_are_redacted() -> None:
     payload = {
         "data": {"fans": [{"fan_id": "a", "mqtt_password": SECRET}]},
     }
-    assert (
-        redact(payload)["data"]["fans"][0]["mqtt_password"] == REDACTED
-    )
+    assert redact(payload)["data"]["fans"][0]["mqtt_password"] == REDACTED
     assert redact(payload)["data"]["fans"][0]["fan_id"] == "a"
 
 
@@ -119,8 +118,6 @@ async def test_authenticate_does_not_log_password(
     to fail -- no network here -- which is fine, because the request body is
     logged before the call is made.
     """
-    from pysmartcocoon.api import SmartCocoonAPI
-
     caplog.set_level(logging.DEBUG, logger="pysmartcocoon")
 
     api = SmartCocoonAPI(request_timeout=1)

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for credential redaction in debug logging.
+
+The point of these tests is not that `redact` transforms dicts correctly in
+the abstract -- it is that a password enabled at DEBUG level never reaches a
+log file. Several tests therefore assert on captured log output rather than
+on return values.
+"""
+
+import json
+import logging
+
+import pytest
+
+from pysmartcocoon.const import API_AUTH_URL, API_HEADERS
+from pysmartcocoon.redact import REDACTED, mask_identifier, redact
+
+SECRET = "hunter2-correct-horse"
+
+
+def test_password_is_redacted() -> None:
+    """A request body's password must never survive redaction."""
+    body = {"email": "dave@example.com", "password": SECRET}
+    assert redact(body)["password"] == REDACTED
+
+
+def test_redaction_does_not_mutate_input() -> None:
+    """Redaction must not corrupt the payload actually sent to the API."""
+    body = {"email": "dave@example.com", "password": SECRET}
+    redact(body)
+    assert body["password"] == SECRET
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "password",
+        "Password",
+        "mqtt_password",
+        "access-token",
+        "refresh_token",
+        "TOKEN",
+        "api_key",
+        "apikey",
+        "secret",
+        "authorization",
+        "client",
+    ],
+)
+def test_sensitive_keys_are_redacted(key: str) -> None:
+    """Credential-bearing keys are matched case-insensitively."""
+    assert redact({key: SECRET})[key] == REDACTED
+
+
+def test_auth_triple_is_fully_covered() -> None:
+    """access-token, client and uid together are this API's credential.
+
+    Redacting only the token would still leak two thirds of it.
+    """
+    headers = {
+        **API_HEADERS,
+        "access-token": "tok",
+        "client": "cli",
+        "uid": "dave@example.com",
+    }
+    result = redact(headers)
+    assert result["access-token"] == REDACTED
+    assert result["client"] == REDACTED
+    assert "dave" not in result["uid"]
+
+
+def test_non_sensitive_values_are_preserved() -> None:
+    """Redaction must leave ordinary debugging detail intact."""
+    payload = {"fan_id": "abc123", "mode": "always_on", "power": 33}
+    assert redact(payload) == payload
+
+
+def test_nested_and_listed_secrets_are_redacted() -> None:
+    """Secrets nested in lists and sub-dicts are still found."""
+    payload = {
+        "data": {"fans": [{"fan_id": "a", "mqtt_password": SECRET}]},
+    }
+    assert (
+        redact(payload)["data"]["fans"][0]["mqtt_password"] == REDACTED
+    )
+    assert redact(payload)["data"]["fans"][0]["fan_id"] == "a"
+
+
+def test_email_is_masked_but_domain_kept() -> None:
+    """Enough is kept to tell accounts apart; the local part is not."""
+    masked = mask_identifier("dave@example.com")
+    assert masked == "d***@example.com"
+    assert "dave@example.com" not in masked
+
+
+def test_mask_identifier_handles_odd_values() -> None:
+    """Masking must not raise on empty or non-string input."""
+    assert mask_identifier("") == ""
+    assert mask_identifier(None) is None
+    assert mask_identifier(12345) == 12345
+    assert mask_identifier("nodomain") == "n***"
+
+
+def test_password_absent_from_serialised_debug_output() -> None:
+    """The realistic failure: a password reaching a pasted log."""
+    body = {"email": "dave@example.com", "password": SECRET}
+    rendered = json.dumps(redact(body), indent=2)
+    assert SECRET not in rendered
+
+
+@pytest.mark.asyncio
+async def test_authenticate_does_not_log_password(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end guard over the actual logging path.
+
+    Exercises SmartCocoonAPI.async_request with DEBUG enabled and asserts the
+    password never appears in emitted records. The request itself is expected
+    to fail -- no network here -- which is fine, because the request body is
+    logged before the call is made.
+    """
+    from pysmartcocoon.api import SmartCocoonAPI
+
+    caplog.set_level(logging.DEBUG, logger="pysmartcocoon")
+
+    api = SmartCocoonAPI(request_timeout=1)
+    with pytest.raises(Exception):
+        await api.async_request(
+            "POST",
+            API_AUTH_URL,
+            json={"email": "dave@example.com", "password": SECRET},
+        )
+
+    assert SECRET not in caplog.text
+    assert REDACTED in caplog.text


### PR DESCRIPTION
## The problem

Debug logging dumped whole API requests and responses verbatim. The authentication request body is `{"email": ..., "password": ...}`, so **enabling debug logging wrote the account password to the log in plaintext**.

This isn't hypothetical. [README.md:200](https://github.com/davecpearce/pysmartcocoon/blob/main/README.md) instructs Home Assistant users to do exactly this when troubleshooting:

```yaml
logger:
  logs:
    pysmartcocoon: debug
```

So the path is: vents misbehave → user follows the documented debug steps → password lands in `home-assistant.log` → user pastes that log into a GitHub issue asking for help.

The same blocks also leaked:

| What | Where |
|---|---|
| Bearer token + API client id | request/response header dumps |
| Account email (`uid`) | header dumps, auth success block |
| Per-fan `mqtt_password` | response body dumps |

`access-token`, `client` and `uid` together *are* this API's credential — redacting only the token would still leak two thirds of it.

I grepped both repos before writing this: no redaction of any kind existed.

## The fix

New `pysmartcocoon/redact.py`, applied at every site that serialises request or response content.

- Secrets → `**REDACTED**`
- Emails → `d***@example.com`, keeping the domain so two accounts can still be told apart, which is the only reason to want the value

Key matching is case-insensitive **substring** (`password`, `token`, `secret`, `authorization`, `api_key`) so new spellings the API introduces are covered without enumerating them — `mqtt_password` and `refresh_token` both match for free. `client` is matched by exact name: innocuous word, but a credential here.

Redaction **copies rather than mutates**, so passing a live request body through it cannot corrupt what is actually sent to the API. There's a test for that specifically.

## Tests

20 new tests. The important one is `test_authenticate_does_not_log_password`, which drives the real `async_request` logging path with DEBUG enabled and asserts the password never appears in the emitted records — because the property that matters is "a password never reaches a log", not "this function transforms dicts correctly".

Full suite: 23 passed.

## Note for the release

The changelog entry tells users to **treat their SmartCocoon password as exposed if they ever enabled debug logging**, and to check anything they've shared publicly. That advice matters more than the fix itself for anyone already affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)