### PR TITLE
fix(ci): trigger release on unprefixed tags too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ name: Release
 on:
   push:
     tags:
+      # Both spellings are matched deliberately. `bumpver update` -- the
+      # documented way to release here -- creates an unprefixed tag (1.4.3),
+      # while the 1.4.0-1.4.2 tags in this repo carry a `v`. Matching only
+      # one spelling means a release tags and pushes but never publishes,
+      # and does so silently, because no workflow run is ever created.
+      - "[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 env:


### PR DESCRIPTION
## The bug

The release workflow triggered only on `v[0-9]+.[0-9]+.[0-9]+`, but **`bumpver update` — the documented way to release here — creates an unprefixed tag**:

```
INFO - git tag --annotate 1.4.3 --message '1.4.3'
```

Verified by running `bumpver update --patch` in a throwaway clone.

So the 1.4.3 release would have bumped the version, committed, tagged, pushed — and published nothing. **Silently**, because a tag that matches no trigger creates no workflow run at all. There is no failed job to notice; the release simply doesn't exist on PyPI.

This also explains the mixed tag history: `1.3.0`/`1.3.1` are unprefixed (bumpver), `v1.4.0`–`v1.4.2` carry a `v` (created by hand).

## The fix

Match both spellings. The version guard already does `${GITHUB_REF_NAME#v}`, so it handles either without change.

Caught before cutting 1.4.3 — the redaction fix in #152 is waiting on this to ship.