### PR TITLE
fix: track aiohttp session ownership and stop closing it mid-retry

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,14 @@ jobs:
       - name: Run pre-commit on all files
         run: |
           pre-commit run --all-files --color=always
-      - name: Run mypy (scoped)
+      # Previously scoped to const.py and types.py only, which left the
+      # strict settings in pyproject.toml (disallow_untyped_defs and friends)
+      # unenforced across the modules that actually do the work. The whole
+      # package passes as-is, so there was nothing to gain by narrowing it.
+      - name: Run mypy
         run: |
           python -m pip install mypy
-          mypy pysmartcocoon/const.py pysmartcocoon/types.py
+          mypy pysmartcocoon
       - name: Run pytest (excluding integration tests)
         run: |
           pytest tests/ -v -k "not integration"

--- a/pysmartcocoon/api.py
+++ b/pysmartcocoon/api.py
@@ -33,6 +33,11 @@ class SmartCocoonAPI:
         request_timeout: int = DEFAULT_TIMEOUT,
     ) -> None:
         self._session = session
+        # A session passed in belongs to the caller. Only a session this
+        # class creates itself may be closed by it -- Home Assistant shares
+        # one aiohttp session across every integration, so closing that would
+        # break unrelated ones.
+        self._owns_session = False
         self._request_timeout = request_timeout
         self._authenticated = False
         self._api_client: Optional[str] = None
@@ -48,10 +53,34 @@ class SmartCocoonAPI:
     async def __aexit__(self, *_: Any) -> None:
         await self.close()
 
+    def _ensure_session(self) -> ClientSession:
+        """Return the session to use, creating one on first use if needed.
+
+        The session is kept for the lifetime of this object rather than
+        created per request, so connections are reused and -- importantly --
+        a retry does not run against a session that has already been closed.
+        """
+        if self._session is None or (
+            self._owns_session and self._session.closed
+        ):
+            self._session = ClientSession(
+                timeout=ClientTimeout(total=self._request_timeout)
+            )
+            self._owns_session = True
+        return self._session
+
     async def close(self) -> None:
-        """Close internally-owned session if present."""
-        if self._session and not self._session.closed:
-            await self._session.close()
+        """Close the session, but only if this instance created it.
+
+        A caller-supplied session is deliberately left open. Home Assistant
+        passes its shared aiohttp session here, and closing that would break
+        every other integration in the instance.
+        """
+        if self._owns_session and self._session is not None:
+            if not self._session.closed:
+                await self._session.close()
+            self._session = None
+            self._owns_session = False
 
     async def async_authenticate(self, username: str, password: str) -> bool:
         """Function to authenticate user with API"""
@@ -91,15 +120,7 @@ class SmartCocoonAPI:
             the Response object corresponding to the result of the API request.
         """
         # pylint: disable=broad-except
-        use_running_session = self._session and not self._session.closed
-
-        if use_running_session:
-            session = self._session
-        else:
-            timeout_value = ClientTimeout(total=self._request_timeout)
-            session = ClientSession(timeout=timeout_value)
-
-        assert session
+        session = self._ensure_session()
 
         data = None
 
@@ -214,9 +235,6 @@ class SmartCocoonAPI:
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("API call to SmartCocoon failed")
                 raise RequestError(str(err)) from err
-            finally:
-                if not use_running_session:
-                    await session.close()
 
         # If this request is for authorization, save auth data
         if url == API_AUTH_URL:

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for aiohttp session ownership and reuse.
+
+Two distinct bugs are covered here:
+
+1. The retry loop closed its session inside the loop body, so attempts 2 and
+   3 ran against a closed session. Retries silently never worked for anyone
+   not supplying their own session.
+2. `close()` closed the caller's session. Home Assistant passes its shared
+   session, so calling it would have taken down every other integration.
+"""
+
+import asyncio
+
+import pytest
+from aiohttp import ClientSession
+
+from pysmartcocoon.api import SmartCocoonAPI
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_session_is_not_closed() -> None:
+    """close() must leave a session it did not create alone.
+
+    Home Assistant shares one aiohttp session across all integrations.
+    """
+    session = ClientSession()
+    try:
+        api = SmartCocoonAPI(session)
+        await api.close()
+        assert not session.closed
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_owned_session_is_closed() -> None:
+    """A session the API created itself is closed by close()."""
+    api = SmartCocoonAPI()
+    created = api._ensure_session()  # pylint: disable=protected-access
+    assert not created.closed
+
+    await api.close()
+    assert created.closed
+
+
+@pytest.mark.asyncio
+async def test_session_is_reused_across_requests() -> None:
+    """The same session is returned each time, not recreated per request.
+
+    This is what makes retries work: a second attempt must not find the
+    session closed underneath it.
+    """
+    api = SmartCocoonAPI()
+    try:
+        first = api._ensure_session()  # pylint: disable=protected-access
+        second = api._ensure_session()  # pylint: disable=protected-access
+        assert first is second
+        assert not first.closed
+    finally:
+        await api.close()
+
+
+@pytest.mark.asyncio
+async def test_caller_session_is_returned_unchanged() -> None:
+    """A supplied session is used as-is rather than replaced."""
+    session = ClientSession()
+    try:
+        api = SmartCocoonAPI(session)
+        in_use = api._ensure_session()  # pylint: disable=protected-access
+        assert in_use is session
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_session_survives_failed_attempts() -> None:
+    """The regression test for the retry bug.
+
+    Previously the session was closed in a `finally` inside the retry loop,
+    so it was already closed once the request returned. Drive a request that
+    fails against an unroutable address and assert the session is still
+    usable afterwards.
+    """
+    api = SmartCocoonAPI(request_timeout=1)
+    try:
+        session = api._ensure_session()  # pylint: disable=protected-access
+
+        with pytest.raises(Exception):
+            await api.async_request(
+                "GET", "http://127.0.0.1:9/never-listening"
+            )
+
+        assert not session.closed
+        after = api._ensure_session()  # pylint: disable=protected-access
+        assert after is session
+    finally:
+        await api.close()
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    """Calling close() twice must not raise."""
+    api = SmartCocoonAPI()
+    api._ensure_session()  # pylint: disable=protected-access
+    await api.close()
+    await api.close()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_closes_owned_session() -> None:
+    """__aexit__ closes a session the API owns."""
+    async with SmartCocoonAPI() as api:
+        created = api._ensure_session()  # pylint: disable=protected-access
+    assert created.closed
+
+
+@pytest.mark.asyncio
+async def test_context_manager_leaves_caller_session_open() -> None:
+    """__aexit__ must not close a caller-supplied session either."""
+    session = ClientSession()
+    try:
+        async with SmartCocoonAPI(session):
+            pass
+        assert not session.closed
+    finally:
+        await session.close()
+
+
+def test_no_event_loop_needed_to_construct() -> None:
+    """Constructing the API must not create a session eagerly.
+
+    aiohttp requires a running loop to create a ClientSession, so building
+    one in __init__ would make SmartCocoonAPI unusable outside async code.
+    """
+    api = SmartCocoonAPI()
+    assert api._session is None  # pylint: disable=protected-access
+
+    async def _use() -> None:
+        api._ensure_session()  # pylint: disable=protected-access
+        await api.close()
+
+    asyncio.run(_use())


### PR DESCRIPTION
Two bugs with a shared cause: **nothing recorded who owned the session.**

## 1. Retries never worked

The retry loop closed its session in a `finally` **inside the loop body** — which runs on `continue`, not just on exit:

```python
for attempt in range(1, max_attempts + 1):
    try:
        ...
    except (ClientConnectionError, asyncio.TimeoutError):
        if attempt < max_attempts:
            continue          # <-- finally fires here
    finally:
        if not use_running_session:
            await session.close()
```

So whenever the caller didn't supply a session, attempt 1 closed it and attempts 2 and 3 ran against a **closed session**, failing instantly and surfacing as a hard `RequestError`.

Every transient 429, 5xx and timeout became a failure for standalone library users. Home Assistant was unaffected — it passes `async_get_clientsession(hass)`, so `use_running_session` was true and the branch never fired. The retry code has been dead for everyone else.

## 2. `close()` closed the *caller's* session

```python
async def close(self) -> None:
    """Close internally-owned session if present."""
    if self._session and not self._session.closed:
        await self._session.close()
```

It never was internally owned. Internally-created sessions were **locals inside `async_request`**; `self._session` only ever held the one passed in by the caller.

Home Assistant shares a single aiohttp session across every integration. A call to `close()` would have closed it and broken unrelated integrations.

Latent rather than live: nothing calls it today. The README's Quick Start reaches for `manager._api.close()`, and `SmartCocoonManager` exposes no path to it.

## The fix

Track ownership explicitly with `_owns_session`, create the session lazily in `_ensure_session()`, and keep it for the object's lifetime.

- `close()` closes **only** what this class created. A caller-supplied session is left alone.
- The session survives across retry attempts, so the retry logic works.
- Connections are reused across requests rather than a fresh session per call.
- Construction stays lazy — building a `ClientSession` in `__init__` needs a running loop and would make the class unusable from sync code. There's a test for that.

## Also: mypy scope

CI ran `mypy pysmartcocoon/const.py pysmartcocoon/types.py` — two files. The strict settings in `pyproject.toml` (`disallow_untyped_defs` and friends) were unenforced across every module that does real work.

Widened to the whole package. **It already passes as-is**, so nothing was gained by narrowing it.

## Tests

9 new tests covering both ownership directions, reuse, idempotent close, and the context manager.

Verified as genuine regression tests — `test_caller_supplied_session_is_not_closed` fails against the old code:

```
assert not session.closed
E   assert not True
```

Full suite: 32 passed. black clean, pylint 10.00/10, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)