### PR TITLE
chore: update pre-commit hooks to stable, and stop autoupdate proposing betas

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,15 +13,77 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.12"
+          # Matches the project's requires-python rather than trailing it.
+          python-version: "3.13"
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          pip install pre-commit
+          pip install pre-commit packaging
       - name: Run pre-commit autoupdate
-        run: pre-commit autoupdate
-      - name: Run hooks to surface breaking changes
-        run: pre-commit run --all-files || true
+        run: |
+          cp .pre-commit-config.yaml /tmp/pre-commit-config.before
+          pre-commit autoupdate
+
+      # `pre-commit autoupdate` takes each repo's newest *tag*, which says
+      # nothing about whether that tag is a release. It has proposed
+      # `isort 9.0.0b1` and `prettier v4.0.0-alpha.8` here before. Revert any
+      # rev that resolves to a pre-release, so only stable versions are ever
+      # offered.
+      - name: Revert pre-release revs
+        run: |
+          python - <<'PY'
+          import pathlib, re
+
+          from packaging.version import InvalidVersion, Version
+
+          before = pathlib.Path("/tmp/pre-commit-config.before").read_text()
+          after_path = pathlib.Path(".pre-commit-config.yaml")
+          after = after_path.read_text()
+
+          rev = re.compile(r"^(\s*rev:\s*)(\S+)\s*$")
+          _TEXTUAL_PRE = re.compile(r"(alpha|beta|dev|rc|pre)", re.I)
+
+          def is_prerelease(raw: str) -> bool:
+              cleaned = raw.strip().strip("'\"").lstrip("vV")
+              try:
+                  return Version(cleaned).is_prerelease
+              except InvalidVersion:
+                  # Tags like v4.0.0-alpha.8 are not PEP 440; fall back to
+                  # looking for the usual pre-release words.
+                  return bool(_TEXTUAL_PRE.search(cleaned))
+
+          old_revs = [m.group(2) for m in map(rev.match, before.splitlines()) if m]
+          out, idx, reverted = [], 0, []
+
+          for line in after.splitlines():
+              match = rev.match(line)
+              if not match:
+                  out.append(line)
+                  continue
+              new = match.group(2)
+              old = old_revs[idx] if idx < len(old_revs) else new
+              idx += 1
+              if new != old and is_prerelease(new):
+                  reverted.append(f"{old} (kept) instead of {new}")
+                  out.append(f"{match.group(1)}{old}")
+              else:
+                  out.append(line)
+
+          after_path.write_text("\n".join(out) + "\n")
+          for item in reverted:
+              print(f"::notice::pre-release skipped: {item}")
+          print(f"{len(reverted)} pre-release rev(s) reverted")
+          PY
+
+      # Not `|| true`. A hook that fails after an update is exactly what a
+      # human needs to know before merging, so record it and say so in the
+      # pull request rather than opening a green-looking PR over a broken
+      # toolchain.
+      - name: Run hooks
+        id: hooks
+        continue-on-error: true
+        run: pre-commit run --all-files --color=always
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
@@ -29,7 +91,15 @@ jobs:
           title: "chore: pre-commit autoupdate"
           body: |
             Automated pre-commit hook updates.
+
             - Ran `pre-commit autoupdate`
-            - Executed hooks to surface potential breakages
+            - Pre-release revs (alpha/beta/rc) were reverted to the
+              previous stable pin
+            - `pre-commit run --all-files`:
+              **${{ steps.hooks.outcome == 'success' && 'passed' || 'FAILED — review before merging' }}**
+
+            > Note: this branch is pushed with `GITHUB_TOKEN`, so GitHub
+            > will not start workflow runs for it and the required checks
+            > cannot report. Close and reopen the PR to get CI to run.
           branch: chore/pre-commit-autoupdate-bot
           delete-branch: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 25.11.0
+    rev: 26.5.1
     hooks:
       - id: black
         args:
@@ -30,7 +30,7 @@ repos:
           - --max-line-length=79
           - --ignore-imports=yes
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.2
+    rev: 1.9.4
     hooks:
       - id: bandit
         args:
@@ -38,7 +38,7 @@ repos:
           - --format=custom
           - --configfile=tests/bandit.yaml
   - repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Replaces #129, which I closed.

## What was wrong with the automated PR

**It proposed a pre-release.** `isort` bumped to **9.0.0b1** — a beta — when stable is 8.0.1. `pre-commit autoupdate` takes each repo's newest *tag*, which says nothing about whether that tag is a release. Betas and alphas get offered for the CI toolchain automatically, every month.

**It could never be validated.** The branch had *no checks at all*. `peter-evans/create-pull-request` pushes with `GITHUB_TOKEN`, and GitHub deliberately does not start workflow runs for those (recursion guard). So the PR was untestable — and under branch protection it can never satisfy the required `Pre-commit` check either.

## Hooks updated by hand, stable only

```
black   25.11.0 -> 26.5.1
bandit  1.9.2   -> 1.9.4
isort   7.0.0   -> 8.0.1
```

Verified locally — `black --check` and `isort --check-only` both report **no changes** to the codebase, despite black crossing a major version.

**prettier stays on v3.1.0.** `pre-commit/mirrors-prettier` is **archived**, and `v4.0.0-alpha.8` is its final tag — there is no stable version to move to. Worth noting `hacs_smartcocoon` already carries that alpha, acquired through this same mechanism. That hook wants replacing rather than bumping; I have left it alone here rather than fold an unrelated change in.

## Stopping it recurring

- **Revert pre-release revs** after autoupdate. Uses `packaging.version` with a textual fallback for non-PEP-440 tags like `v4.0.0-alpha.8`. Unit-checked against every rev in these two repos plus synthetic cases — 12/12 classified correctly.
- **Stop swallowing the hook run.** It was `pre-commit run --all-files || true`, so a hook breaking after an update produced a clean-looking PR anyway. Now the outcome is recorded and stated in the PR body.
- **Say so in the body** that CI cannot run on these branches, and that closing/reopening the PR makes it run.
- **Python 3.13**, matching `requires-python` instead of trailing it at 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)