### PR TITLE
chore: move prettier hook to a maintained mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: 8.0.1
     hooks:
       - id: isort
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
     hooks:
       - id: prettier


### PR DESCRIPTION
`pre-commit/mirrors-prettier` is **archived upstream** and will see no further prettier releases.

This repo was on `v3.1.0`, so unlike `hacs_smartcocoon` it never picked up that mirror's final `v4.0.0-alpha.8` tag — but the repository is dead either way.

Switched to **`rbubley/mirrors-prettier`** (actively maintained) on **`v3.9.6`**.

Companion to davecpearce/hacs_smartcocoon#405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)