### PR TITLE
ci: isolate the schedule so it cannot take pull request CI with it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,25 @@
+---
+name: Nightly
+
+# This file exists to hold the schedule, and nothing else.
+#
+# GitHub disables scheduled workflows after 60 days of repository inactivity,
+# and a disabled workflow reports no status at all rather than failing, so
+# nothing draws attention to it. When that trigger lived in tests.yaml, being
+# disabled would have taken every pull request check with it -- which is
+# precisely what happened in hacs_smartcocoon, unnoticed for ten weeks.
+#
+# Keeping the schedule isolated here bounds the damage to one nightly re-run.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full-ci:
+    name: Full CI
+    uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,14 +1,22 @@
 ---
 name: Linting
 
+# Deliberately no `schedule:` trigger here. GitHub disables scheduled
+# workflows after 60 days of repository inactivity, and a disabled workflow
+# reports nothing at all rather than failing -- so it goes unnoticed. That is
+# what happened to the equivalent file in hacs_smartcocoon, which sat
+# switched off for ten weeks while pull requests merged against stale checks.
+#
+# nightly.yml holds the schedule and calls this workflow instead. If that one
+# is disabled, the loss is a nightly re-run rather than all pull request
+# validation.
 on:
   push:
     branches:
       - main
       - dev
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_call:
 
 env:
   DEFAULT_PYTHON: 3.13.2


### PR DESCRIPTION
Mirrors davecpearce/hacs_smartcocoon#407.

## Why

In `hacs_smartcocoon`, a `schedule:` trigger in the CI workflow meant GitHub's **60-day inactivity rule** disabled the entire pipeline — silently, since a disabled workflow reports no status rather than failing. It went unnoticed for **ten weeks**, during which pull requests merged against months-old checks and a credential leak stayed hidden.

**This repo's `tests.yaml` carried the same nightly schedule and the same exposure.** It has not been disabled yet; this removes the possibility rather than waiting to find out.

## The fix

`nightly.yml` now holds the schedule and does nothing but call `tests.yaml`. The CI workflow triggers on `push`, `pull_request` and `workflow_call` only, so it can never be auto-disabled.

If `nightly.yml` is disabled by the same rule, the loss is one nightly re-run instead of all pull request validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)