### PR TITLE
fix: report fan updates the API rejected instead of claiming success

### DIFF
--- a/pysmartcocoon/fan.py
+++ b/pysmartcocoon/fan.py
@@ -190,17 +190,23 @@ class Fan:
         return self._mqtt_password
 
     def set_speed_pct(self, fan_speed_pct: int) -> bool:
-        """Update the power of the fan"""
+        """Update the power of the fan.
 
-        if fan_speed_pct > 100:
-            _LOGGER.debug(
+        Returns False and leaves the speed unchanged if the value is outside
+        0-100. The previous implementation logged that the value was invalid
+        and then applied it anyway, so a speed of 150 became a power of 15000.
+        """
+
+        if not 0 <= fan_speed_pct <= 100:
+            _LOGGER.warning(
                 (
                     "Fan ID: %s - Fan speed of %s%% is invalid, must be "
-                    "between 0%% and 100%%"
+                    "between 0%% and 100%%. Speed not changed."
                 ),
                 self.fan_id,
                 str(fan_speed_pct),
             )
+            return False
 
         _LOGGER.debug(
             "Fan ID: %s - Updating fan speed to %s%%",
@@ -258,8 +264,10 @@ class Fan:
             return False
 
         # Update power if changed
-        if self.speed_pct != fan_speed_pct:
-            self.set_speed_pct(fan_speed_pct)
+        if self.speed_pct != fan_speed_pct and not self.set_speed_pct(
+            fan_speed_pct
+        ):
+            return False
 
         # Attempt to update the fan via API
         success = await self._async_set_fan(fan_mode)
@@ -284,12 +292,25 @@ class Fan:
             )
             return False
 
-        # Make the API call
-        await self._api.async_update_fan(
+        # Make the API call. async_request returns None for a response it
+        # could not use, without raising, so the result has to be checked --
+        # otherwise a rejected update is reported as a successful one and the
+        # caller displays a speed the fan never accepted.
+        response = await self._api.async_update_fan(
             fan_identifier=self._identifier,
             mode=self.mode,
             power=self.power,
         )
+
+        if response is None:
+            _LOGGER.warning(
+                "Fan ID: %s - API did not accept the update to mode %s, "
+                "speed %s%%",
+                self.fan_id,
+                self.mode,
+                self.speed_pct,
+            )
+            return False
 
         _LOGGER.debug(
             "Fan ID: %s - Fan Mode was set to %s, speed to %s",

--- a/pysmartcocoon/manager.py
+++ b/pysmartcocoon/manager.py
@@ -180,40 +180,53 @@ class SmartCocoonManager:
         _LOGGER.debug(msg)
         return "Unknown"
 
-    async def async_fan_turn_on(self, fan_id: str) -> None:
-        """Turn on fan."""
+    # These return whether the fan actually accepted the change. They
+    # previously returned None, which discarded the result and left callers
+    # unable to tell a rejected update from an applied one. Existing callers
+    # that ignore the return value are unaffected.
 
-        await self._fans[fan_id].async_set_fan_modes(fan_mode=FanMode.ON)
+    async def async_fan_turn_on(self, fan_id: str) -> bool:
+        """Turn on fan. Returns False if the fan did not accept it."""
 
-    async def async_fan_turn_off(self, fan_id: str) -> None:
-        """Turn on fan."""
+        return await self._fans[fan_id].async_set_fan_modes(
+            fan_mode=FanMode.ON
+        )
 
-        await self._fans[fan_id].async_set_fan_modes(fan_mode=FanMode.OFF)
+    async def async_fan_turn_off(self, fan_id: str) -> bool:
+        """Turn off fan. Returns False if the fan did not accept it."""
 
-    async def async_set_fan_auto(self, fan_id: str) -> None:
-        """Enable auto mode on fan."""
+        return await self._fans[fan_id].async_set_fan_modes(
+            fan_mode=FanMode.OFF
+        )
 
-        await self._fans[fan_id].async_set_fan_modes(fan_mode=FanMode.AUTO)
+    async def async_set_fan_auto(self, fan_id: str) -> bool:
+        """Enable auto mode on fan. Returns False if not accepted."""
 
-    async def async_set_fan_eco(self, fan_id: str) -> None:
-        """Enable eco mode on fan."""
+        return await self._fans[fan_id].async_set_fan_modes(
+            fan_mode=FanMode.AUTO
+        )
 
-        await self._fans[fan_id].async_set_fan_modes(fan_mode=FanMode.ECO)
+    async def async_set_fan_eco(self, fan_id: str) -> bool:
+        """Enable eco mode on fan. Returns False if not accepted."""
+
+        return await self._fans[fan_id].async_set_fan_modes(
+            fan_mode=FanMode.ECO
+        )
 
     async def async_set_fan_modes(
         self, fan_id: str, fan_mode: FanMode, fan_speed_pct: int
-    ) -> None:
-        """Set fan mode and speed."""
+    ) -> bool:
+        """Set fan mode and speed. Returns False if not accepted."""
 
-        await self._fans[fan_id].async_set_fan_modes(
+        return await self._fans[fan_id].async_set_fan_modes(
             fan_mode=fan_mode, fan_speed_pct=fan_speed_pct
         )
 
     async def async_set_fan_speed(
         self, fan_id: str, fan_speed_pct: int
-    ) -> None:
-        """Set fan speed."""
+    ) -> bool:
+        """Set fan speed. Returns False if not accepted."""
 
-        await self._fans[fan_id].async_set_fan_modes(
+        return await self._fans[fan_id].async_set_fan_modes(
             fan_speed_pct=fan_speed_pct
         )

--- a/tests/test_fan_update_failure.py
+++ b/tests/test_fan_update_failure.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests that a rejected fan update is reported as a failure.
+
+`SmartCocoonAPI.async_request` returns None for a response it could not use,
+without raising. The fan previously ignored that and returned True regardless,
+so Home Assistant displayed a speed the fan had never accepted.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from pysmartcocoon.fan import Fan
+from pysmartcocoon.manager import SmartCocoonManager
+
+FAN_ID = "abc123"
+
+
+def _api_payload(power: int = 3300, mode: str = "always_on") -> dict[str, Any]:
+    """A fan payload shaped like the API's, for seeding state."""
+    return {
+        "id": 42,
+        "fan_id": FAN_ID,
+        "mode": mode,
+        "fan_on": True,
+        "firmware_version": "1.0.0",
+        "is_room_estimating": False,
+        "connected": True,
+        "last_connection": None,
+        "power": power,
+        "predicted_room_temperature": 21.0,
+        "room_id": 7,
+        "thermostat_vendor": None,
+        "mqtt_username": "u",
+        "mqtt_password": "p",
+    }
+
+
+class _StubAPI:
+    """Stands in for SmartCocoonAPI with a controllable update result."""
+
+    def __init__(self, update_result: Optional[dict[str, Any]]) -> None:
+        self._update_result = update_result
+        self.update_calls = 0
+
+    async def async_update_fan(
+        self, fan_identifier: int, mode: str, power: int
+    ) -> Optional[dict[str, Any]]:
+        """Return the configured result, standing in for the real API call."""
+        self.update_calls += 1
+        return self._update_result
+
+    async def async_get_fan(
+        self, fan_identifier: int
+    ) -> Optional[dict[str, Any]]:
+        """Return a fixed payload; the refresh path is not under test here."""
+        return _api_payload()
+
+
+async def _seeded_fan(api: Any) -> Fan:
+    fan = Fan(FAN_ID, api)
+    await fan.async_update_api_data(_api_payload())
+    return fan
+
+
+@pytest.mark.asyncio
+async def test_rejected_update_reports_failure() -> None:
+    """The regression test: API returns None, so this must not claim success."""
+    api = _StubAPI(update_result=None)
+    fan = await _seeded_fan(api)
+
+    result = await fan.async_set_fan_modes(fan_speed_pct=50)
+
+    assert api.update_calls == 1
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_accepted_update_reports_success() -> None:
+    """An accepted update still reports success."""
+    api = _StubAPI(update_result=_api_payload())
+    fan = await _seeded_fan(api)
+
+    assert await fan.async_set_fan_modes(fan_speed_pct=50) is True
+
+
+@pytest.mark.asyncio
+async def test_manager_propagates_failure() -> None:
+    """The manager must not swallow the result.
+
+    It previously returned None from these methods, so a caller could not
+    distinguish a rejected update from an applied one.
+    """
+    api = _StubAPI(update_result=None)
+    manager = SmartCocoonManager()
+    # pylint: disable=protected-access
+    manager._fans[FAN_ID] = await _seeded_fan(api)
+
+    assert await manager.async_set_fan_speed(FAN_ID, 50) is False
+    assert await manager.async_fan_turn_on(FAN_ID) is False
+    assert await manager.async_set_fan_auto(FAN_ID) is False
+
+
+@pytest.mark.asyncio
+async def test_manager_propagates_success() -> None:
+    """And reports success when the fan accepts the change."""
+    api = _StubAPI(update_result=_api_payload())
+    manager = SmartCocoonManager()
+    # pylint: disable=protected-access
+    manager._fans[FAN_ID] = await _seeded_fan(api)
+
+    assert await manager.async_set_fan_speed(FAN_ID, 50) is True
+
+
+@pytest.mark.parametrize("speed", [101, 150, -1, -100])
+def test_out_of_range_speed_is_rejected(speed: int) -> None:
+    """Out-of-range speeds must not be applied.
+
+    The previous implementation logged that the value was invalid and then
+    set it anyway, so 150 became a power of 15000.
+    """
+    fan = Fan(FAN_ID, _StubAPI(update_result=None))
+    fan.set_speed_pct(40)
+    assert fan.power == 4000
+
+    assert fan.set_speed_pct(speed) is False
+    assert fan.power == 4000  # unchanged
+
+
+@pytest.mark.parametrize("speed", [0, 1, 50, 99, 100])
+def test_in_range_speed_is_applied(speed: int) -> None:
+    """Boundary values are accepted."""
+    fan = Fan(FAN_ID, _StubAPI(update_result=None))
+    assert fan.set_speed_pct(speed) is True
+    assert fan.power == speed * 100

--- a/tests/test_fan_update_failure.py
+++ b/tests/test_fan_update_failure.py
@@ -37,7 +37,13 @@ def _api_payload(power: int = 3300, mode: str = "always_on") -> dict[str, Any]:
 
 
 class _StubAPI:
-    """Stands in for SmartCocoonAPI with a controllable update result."""
+    """Stands in for SmartCocoonAPI with a controllable update result.
+
+    The signatures mirror SmartCocoonAPI, so the arguments are deliberately
+    accepted and ignored.
+    """
+
+    # pylint: disable=unused-argument
 
     def __init__(self, update_result: Optional[dict[str, Any]]) -> None:
         self._update_result = update_result
@@ -46,14 +52,14 @@ class _StubAPI:
     async def async_update_fan(
         self, fan_identifier: int, mode: str, power: int
     ) -> Optional[dict[str, Any]]:
-        """Return the configured result, standing in for the real API call."""
+        """Return the configured result, standing in for the real call."""
         self.update_calls += 1
         return self._update_result
 
     async def async_get_fan(
         self, fan_identifier: int
     ) -> Optional[dict[str, Any]]:
-        """Return a fixed payload; the refresh path is not under test here."""
+        """Return a fixed payload; the refresh path is not under test."""
         return _api_payload()
 
 
@@ -65,7 +71,7 @@ async def _seeded_fan(api: Any) -> Fan:
 
 @pytest.mark.asyncio
 async def test_rejected_update_reports_failure() -> None:
-    """The regression test: API returns None, so this must not claim success."""
+    """Regression test: API returns None, so this must not claim success."""
     api = _StubAPI(update_result=None)
     fan = await _seeded_fan(api)
 


### PR DESCRIPTION
## The bug

`_async_set_fan` discarded the result of `async_update_fan` and returned `True` unconditionally:

```python
await self._api.async_update_fan(...)   # result thrown away
...
return True                             # always
```

`async_request` returns `None` for a response it could not use — **without raising** ([api.py:284](https://github.com/davecpearce/pysmartcocoon/blob/main/pysmartcocoon/api.py)). So a rejected update was reported as an applied one.

The whole chain then agreed it had worked:

| Layer | Behaviour |
|---|---|
| `_async_set_fan` | returns `True` regardless |
| `async_set_fan_modes` | passes that up |
| `SmartCocoonManager.async_set_fan_speed` | returned `None` — result discarded |
| HA `async_set_percentage` | logs *"Successfully set percentage"*, writes state |

**The user sees the fan at the new speed. The vent never changed.** Worse than a visible failure, because there is nothing to retry.

## The fix

Check the response and return `False` when it is `None`.

That is only observable if the result survives the call chain — and it did not. **Every fan-control method on `SmartCocoonManager` returned `None`**, discarding the bool. They now return it:

```
async_fan_turn_on / async_fan_turn_off / async_set_fan_auto
async_set_fan_eco / async_set_fan_modes / async_set_fan_speed
```

`None` → `bool` is additive; callers that ignore the return are unaffected.

## Also: validation that ignored its own verdict

`set_speed_pct` checked `> 100`, logged *"is invalid"* at **debug** level, then applied the value anyway — 150 became a power of 15000. No lower bound either.

It now leaves the speed unchanged and returns `False`, and `async_set_fan_modes` honours that.

Scope note: on the normal path `resolve_speed` already rejects out-of-range values before this is reached, so this matters for **direct callers of what is a public method**, not for Home Assistant.

## Tests

13 new tests. They are regression tests, not descriptions of existing behaviour — **7 of 13 fail against the previous implementation**:

```
FAILED test_rejected_update_reports_failure
FAILED test_manager_propagates_failure
FAILED test_manager_propagates_success
FAILED test_out_of_range_speed_is_rejected[101]
FAILED test_out_of_range_speed_is_rejected[150]
FAILED test_out_of_range_speed_is_rejected[-1]
FAILED test_out_of_range_speed_is_rejected[-100]
```

Full suite: 45 passed. black clean, pylint 10.00/10, mypy clean on the whole package.

## Follow-up not included

Home Assistant still ignores the returned value and logs success unconditionally in `async_set_percentage`. Surfacing it there is a `hacs_smartcocoon` change and belongs in its own PR — this one makes the information available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)